### PR TITLE
stop the shim from treating gradient-center as a color stop

### DIFF
--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -33,6 +33,11 @@ var _ = self.ConicGradient = function(o) {
 
 	this.stops = (stops || "").split(/\s*,(?![^(]*\))\s*/); // commas that are not followed by a ) without a ( first
 
+	if(/^at\s[^,]/.test(this.stops[0])) {
+		pos_stop = this.stops.shift();
+		console.log("The background-position property is not supported right now.");
+	}
+
 	for (var i=0; i<this.stops.length; i++) {
 		var stop = this.stops[i] = new _.ColorStop(this, this.stops[i]);
 

--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -35,7 +35,7 @@ var _ = self.ConicGradient = function(o) {
 
 	if(/^at\s[^,]/.test(this.stops[0])) {
 		pos_stop = this.stops.shift();
-		console.log("The background-position property is not supported right now.");
+		console.log("The gradient-center position property is not supported right now.");
 	}
 
 	for (var i=0; i<this.stops.length; i++) {

--- a/index.html
+++ b/index.html
@@ -115,6 +115,8 @@ console.log(gradient.blobURL); // blog URL</code></pre>
     <p>Note that the generated image will always resize accordingly, you don’t have to provide a size. The size argument just controls the resolution of the bitmap image generated inside the SVG that will be scaled. Making it smaller will result in faster performance but less crisp gradients.</p>
 
     <p>Also, you can use <a href="https://github.com/jonathantneal/postcss-conic-gradient">PostCSS Conic Gradient</a> to have conic gradient fallbacks added automatically to your CSS file.</p>
+
+    <p>Note that the background-position property, such as <code>at center</code> etc, is not supported right now, and is ignored if present.</p>
 </section>
 
 <section id="ask">


### PR DESCRIPTION
A partial fix for #10. Ideally, the background-position property should also be taken into account. This may come in another commit somewhere down the line ;)
