### PR TITLE
Let users specify the position of the gradient's center

### DIFF
--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -33,6 +33,11 @@ var _ = self.ConicGradient = function(o) {
 
 	this.stops = (stops || "").split(/\s*,(?![^(]*\))\s*/); // commas that are not followed by a ) without a ( first
 
+	if(/^at\s[^,]/.test(this.stops[0])) {
+		pos_stop = this.stops.shift();
+		console.log("The background-position property is not supported right now.");
+	}
+
 	for (var i=0; i<this.stops.length; i++) {
 		var stop = this.stops[i] = new _.ColorStop(this, this.stops[i]);
 

--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -35,7 +35,7 @@ var _ = self.ConicGradient = function(o) {
 
 	if(/^at\s[^,]/.test(this.stops[0])) {
 		pos_stop = this.stops.shift();
-		console.log("The background-position property is not supported right now.");
+		console.log("The gradient-center position property is not supported right now.");
 	}
 
 	for (var i=0; i<this.stops.length; i++) {

--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -302,8 +302,7 @@ _.GradientCenter = function(gradient, position) {
 	if (parts[2] == null) {
 		parts[2] = 'center';
 	}
-
-	var flipped = /^at\s+(?:top|bottom)\s+(?:right|left|center)$/.test(position);
+	var flipped = /^at\s+(?:top|bottom)(?:\s+)?(?:right|left|center)?$/.test(position);
 	if (flipped) {
 		temp = parts[1];
 		parts[1] = parts[2];

--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -134,7 +134,7 @@ _.prototype = {
 	},
 
 	get r() {
-		return Math.sqrt(2) * this.size / 2;
+		return Math.sqrt(2) * this.size;
 	},
 
 	// Paint the conical gradient on the canvas

--- a/index.html
+++ b/index.html
@@ -115,6 +115,8 @@ console.log(gradient.blobURL); // blog URL</code></pre>
     <p>Note that the generated image will always resize accordingly, you don’t have to provide a size. The size argument just controls the resolution of the bitmap image generated inside the SVG that will be scaled. Making it smaller will result in faster performance but less crisp gradients.</p>
 
     <p>Also, you can use <a href="https://github.com/jonathantneal/postcss-conic-gradient">PostCSS Conic Gradient</a> to have conic gradient fallbacks added automatically to your CSS file.</p>
+
+    <p>Note that the background-position property, such as <code>at center</code> etc, is not supported right now, and is ignored if present.</p>
 </section>
 
 <section id="ask">


### PR DESCRIPTION
This PR lets users specify the position of the gradient's center.

Currently, it supports these units:
`px | %`
and the values supported by `background-image`/`transform-origin` properties, namely `top|bottom|left|right|center`.

Also, care is taken so that these two result in the same position:
`(at top left, ...)`
and
`(at left top, ...)`

There is a limitation of the current architecture, which makes the position values to not be relative to the element on which the gradient is applied, but to an arbitary canvas element. This is because the source element is not accessible while the gradient is being painted. This is also the reason that `em` is not supportable right now.
