### PR TITLE
Fix wrong beginning angle and blank line

### DIFF
--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -154,7 +154,7 @@ _.prototype = {
 		c.rotate(-90*deg);
 		c.translate(-this.size/2, -this.size/2);
 
-		for (var i = 0; i < 360; i+=.5) {
+		for (var i = 0; i < 360;) {
 			if (i/360 + ε >= stop.pos) {
 				// Switch color stop
 				do {
@@ -188,28 +188,27 @@ _.prototype = {
 			c.beginPath();
 			c.moveTo(x, x);
 
-			var angle = Math.min(360*deg, i*deg);
-
 			if (sameColor) {
 				var θ = 360 * (stop.pos - prevStop.pos);
-
-				i += θ - .5;
 			}
 			else {
 				var θ = .5;
 			}
 
-			var endAngle = angle + θ*deg;
+			var beginArg = i*deg;
+			beginArg = Math.min(360*deg, beginArg);
 
-			endAngle = Math.min(360*deg, endAngle);
+			// .02: To prevent empty blank line and corresponding moire
+			// only non-alpha colors are cared now
+			var endArg = beginArg + θ*deg;
+			endArg = Math.min(360*deg, endArg + .02);
 
-			// 0.02: To prevent moire
-			var arc = endAngle - angle;
-			c.arc(x, x, radius, arc >= 2*deg? angle : angle - .02, endAngle);
+			c.arc(x, x, radius, beginArg, endArg);
 
 			c.closePath();
 			c.fill();
 
+			i += θ;
 		}
 	}
 };


### PR DESCRIPTION
This changeset fixes #17, not only in context of white (blank) lines but also in angles and colors; and also it almost fixes #4. (I don't know why #4 is not totally fixed.)

The reason was that previous code was decreasing the beginning angle to overlap the narrow arcs to fix blank lines and correspoiding moire effect. As the drawing code procedes way from the beginning angle to the ending angle, ending angle of the arc should be increased to be overlapped. Also, the white blank line appearing in #17 is what caused moire; so the overlapping strategy is applied for every case from now on.