### PR TITLE
feat: add support for MS Edge/IE11

### DIFF
--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -113,7 +113,10 @@ _.prototype = {
 	},
 
 	get dataURL() {
-		return "data:image/svg+xml," + this.svg;
+		// IE/Edge only render data-URI based background-image when the image data
+		// is escaped.
+		// Ref: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/7157459/#comment-3
+		return "data:image/svg+xml," + encodeURIComponent(this.svg);
 	},
 
 	get blobURL() {

--- a/index.html
+++ b/index.html
@@ -28,11 +28,11 @@ border-radius: 50%"></article>
 background: conic-gradient(black 25%, white 0 50%, black 0 75%, white 0);
 background-size: 4em 4em;"></article>
     <article style="/* Alpha and multiple backgrounds */
-background: 
+background:
     conic-gradient(#f06, rgba(0,0,0,.5)),
     conic-gradient(silver 25%, #eee 0 50%,
                    silver 0 75%, #eee 0);
-background-size: auto, 1em 1em;"></article> 
+background-size: auto, 1em 1em;"></article>
         <article style="/* Starburst with repeating gradients */
 background: #0ac
 repeating-conic-gradient(hsla(0,0%,100%,.2) 0 15deg, hsla(0,0%,100%,0) 0 30deg);"></article>
@@ -44,7 +44,7 @@ repeating-conic-gradient(hsla(0,0%,100%,.2) 0 15deg, hsla(0,0%,100%,0) 0 30deg);
     <blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">The emulate 3D with conic-gradient demo again, now with an image (+working in WebKit browsers) <a href="http://t.co/ZzAqwKLdaT">http://t.co/ZzAqwKLdaT</a> <a href="http://t.co/jdAEgGDnuI">pic.twitter.com/jdAEgGDnuI</a></p>&mdash; Ana Tudor (@anatudor) <a href="https://twitter.com/anatudor/status/632597393985413121">August 15, 2015</a></blockquote>
 
     <blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Another demo using `conic-gradient` for bouncing cube&#39;s faces (I hate animation) <a href="http://t.co/YXwJGaGQaM">http://t.co/YXwJGaGQaM</a> cc <a href="https://twitter.com/LeaVerou">@LeaVerou</a> <a href="http://t.co/BEnimSXeMN">pic.twitter.com/BEnimSXeMN</a></p>&mdash; Ana Tudor (@anatudor) <a href="https://twitter.com/anatudor/status/632609444258562048">August 15, 2015</a></blockquote>
-    
+
     <blockquote class="twitter-tweet" data-conversation="none" lang="en"><p lang="en" dir="ltr">And an actually practical one: a metallic looking button! <a href="http://t.co/0SLAHN8gKL">http://t.co/0SLAHN8gKL</a> <a href="https://twitter.com/LeaVerou">@LeaVerou</a> <a href="http://t.co/lmv98tp2nK">pic.twitter.com/lmv98tp2nK</a></p>&mdash; Ana Tudor (@anatudor) <a href="https://twitter.com/anatudor/status/611732004531478528">June 19, 2015</a></blockquote>
 
     <blockquote class="twitter-tweet" lang="en"><p lang="en" dir="ltr">Cog animation using <a href="https://twitter.com/hashtag/conicGradient?src=hash">#conicGradient</a> (css polyfill made by <a href="https://twitter.com/LeaVerou">@LeaVerou</a>) <a href="http://t.co/wH95eZTO2s">http://t.co/wH95eZTO2s</a> (now with screenshot) <a href="http://t.co/d7Bif13Hwo">pic.twitter.com/d7Bif13Hwo</a></p>&mdash; Ryan (@ryanantonydunn) <a href="https://twitter.com/ryanantonydunn/status/613263784476569601">June 23, 2015</a></blockquote>
@@ -125,11 +125,11 @@ console.log(gradient.blobURL); // blog URL</code></pre>
     <h1>How can I get conic gradients implemented?</h1>
 
     <p>The best way to get a feature implemented is asking browser vendors to do it. It’s really that simple. Browser vendors prioritize what to implement based on developer requests, so the more developers asking for a feature, the higher the chances browsers will notice.</p>
-    
+
     <a href="https://twitter.com/share" class="twitter-share-button" data-text="Conic gradients are awesome. Please implement them @MSEdgeDev @mozhacks @ChromiumDev @odevrel @webkit" data-via="LeaVerou">Tweet</a>
     <a href="https://twitter.com/share" class="twitter-share-button" data-text="Conic gradients are awesome. Please implement them @MSEdgeDev @mozhacks @ChromiumDev @odevrel @webkit" data-via="LeaVerou">Tweet</a>
     <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
-    
+
     <p>Also, communicate directly with the developers. Vote or comment in the following:</p>
 
     <ul>
@@ -147,8 +147,9 @@ console.log(gradient.blobURL); // blog URL</code></pre>
     Made with &hearts; by <a href="http://lea.verou.me">Lea Verou</a> &bull; <a href="http://lea.verou.me/2015/06/conical-gradients-today">Blog post</a>
 </footer>
 
-<script src="../prefixfree/prefixfree.min.js"></script>
-<script src="../incrementable/incrementable.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/prefixfree/1.0.7/prefixfree.min.js"></script>
+<script src="https://rawgit.com/LeaVerou/incrementable/68101ce82994f1398834711e5665c46e68b289ba/incrementable.js"></script>
+
 <script src="conic-gradient.js"></script>
 <script src="index.js"></script>
 


### PR DESCRIPTION
This fix makes Edge & IE11 show the beautiful conic gradients in all their glory! 🎉 

Caveats
- There is a bug while viewing in IE, where the *initial* values for conic-gradient are not applied, and are also removed from the 'style' attribute in the DOM. But if the style is manually re-written in the text-area, IE will also display the correct background.