### PR TITLE
Fix floating-point error

### DIFF
--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -172,7 +172,7 @@ _.prototype = {
 
 					stopIndex++;
 					stop = this.stops[stopIndex];
-				// Consider position being the same if in differs no more than by ε
+				// Continue while point is behind current position (i)
 				} while(stop && stop != prevStop && i/360 + ε >= stop.pos);
 
 				if (!stop) {

--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -66,7 +66,7 @@ var _ = self.ConicGradient = function(o) {
 		this.stops.unshift(first);
 	}
 
-	// Add dummy last stop or set first stop’s position to 100% if it doesn’t have one
+	// Add dummy last stop or set last stop’s position to 100% if it doesn’t have one
 	if (this.stops[this.stops.length - 1].pos === undefined) {
 		this.stops[this.stops.length - 1].pos = 1;
 	}
@@ -172,7 +172,8 @@ _.prototype = {
 
 					stopIndex++;
 					stop = this.stops[stopIndex];
-				} while(stop && stop != prevStop && stop.pos === prevStop.pos);
+				// Consider position being the same if in differs no more than by ε
+				} while(stop && stop != prevStop && Math.abs(stop.pos - prevStop.pos) < ε);
 
 				if (!stop) {
 					break;

--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -173,7 +173,7 @@ _.prototype = {
 					stopIndex++;
 					stop = this.stops[stopIndex];
 				// Consider position being the same if in differs no more than by ε
-				} while(stop && stop != prevStop && Math.abs(stop.pos - prevStop.pos) < ε);
+				} while(stop && stop != prevStop && i/360 + ε >= stop.pos);
 
 				if (!stop) {
 					break;


### PR DESCRIPTION
The `stop.pos` values are floats, so sometimes it occurs that they are different by some tiny values when they're actually intended to be the same. I replaced strict comparison of `pos` values with checking that next stop is still behind current position + epsilon. This fixes #4 & #22 

The fix can also be noticed on examples site.
Before:
<img width="312" alt="screen shot 2018-03-28 at 01 52 50" src="https://user-images.githubusercontent.com/6651625/37999955-ef669cd2-322d-11e8-8ebe-99caf736ab5b.png">
After:
<img width="314" alt="screen shot 2018-03-28 at 02 14 58" src="https://user-images.githubusercontent.com/6651625/37999960-f5fcf5e6-322d-11e8-9572-1ed0f41ea494.png">

