### PR TITLE
Append dummy to body instead of head

### DIFF
--- a/conic-gradient.js
+++ b/conic-gradient.js
@@ -12,7 +12,7 @@ var ε = .00001;
 var deg = π/180;
 
 var dummy = document.createElement("div");
-document.head.appendChild(dummy);
+document.body.appendChild(dummy);
 
 var _ = self.ConicGradient = function(o) {
 	var me = this;


### PR DESCRIPTION
Appending `div` to `head` creates invalid HTML:

https://validator.w3.org/nu/?doc=data:text/html;charset=utf-8,%3C%21DOCTYPE%20html%3E%0D%0A%3Chtml%20lang%3D%22en%22%3E%0D%0A%3Chead%3E%0D%0A%3Ctitle%3EFoo%3C%2Ftitle%3E%0D%0A%3Cdiv%3E%3C%2Fdiv%3E%0D%0A%3C%2Fhead%3E%0D%0A%3Cbody%3E%0D%0A%3C%2Fbody%3E%0D%0A%3C%2Fhtml%3E

(Sorry about the scary URL, I'm trying to figure out a minimal test case to illustrate.)

Attempting to pass the following HTML through an HTML validator:

```html
<!DOCTYPE html><html lang="en"><head><title>Foo</title><div></div></head><body></body></html>
```

...returns the following errors:

1. Error: Stray end tag head.
    From line 1, column 67; to line 1, column 73
    `div></div></head><body>`
2. Error: Start tag body seen but an element of the same type was already open.
    From line 1, column 74; to line 1, column 79
    `iv></head><body></body`

Generally, I'd say that being flagged by a validator isn't _that_ big of an issue, but it can cause accessibility problems, and this feels like an easy fix. If you work with an accessibility expert, one of the first things they might tell you is that your code (after JavaScript execution) should pass standard HTML 5 validation. This will ensure compatibility with the greatest range of screen reader software—and hopefully, improve compatibility with older normal browsers, too!

**Edit:** Originally fixed by @nikhiltri in our own project.